### PR TITLE
Modify https://github.com/jupyter-server/jupyter_server/pull/1367

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -122,7 +122,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupytext
-          test_command: pip install pytest-jupyter[server] gitpython && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes --ignore=tests/test_doc_files_are_notebooks.py --ignore=tests/test_changelog.py
+          test_command: pip install pytest-jupyter[server] gitpython pre-commit && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes --ignore=tests/test_doc_files_are_notebooks.py --ignore=tests/test_changelog.py
 
   downstream_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -118,15 +118,11 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-      - name: Install some missing tests dependencies
-        run: |
-          pip install gitpython
-
       - name: Test jupytext
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupytext
-          test_command: pip install pytest-jupyter[server] && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes --ignore=tests/test_doc_files_are_notebooks.py
+          test_command: pip install pytest-jupyter[server] gitpython && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes --ignore=tests/test_doc_files_are_notebooks.py --ignore=tests/test_changelog.py
 
   downstream_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -122,7 +122,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupytext
-          test_command: pip install jupytext[test] && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes
+          test_command: pip install pytest-jupyter[server] && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes
 
   downstream_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -122,7 +122,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupytext
-          test_command: pip install jupytextr[test] && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes
+          test_command: pip install jupytext[test] && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes
 
   downstream_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -107,6 +107,23 @@ jobs:
           test_command: pip install pytest-jupyter[server] && pytest -vv -raXxs -W default --durations 10 --color=yes
           package_name: jupyter_server_terminals
 
+  jupytext:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Test jupytext
+        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: jupytext
+          test_command: pip install jupytextr[test] && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes
+
   downstream_check: # This job does nothing and is only used for the branch protection
     if: always()
     needs:
@@ -115,6 +132,7 @@ jobs:
       - jupyterlab_server
       - notebook
       - nbclassic
+      - jupytext
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -118,11 +118,15 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
+      - name: Install some missing tests dependencies
+        run: |
+          pip install gitpython
+
       - name: Test jupytext
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupytext
-          test_command: pip install pytest-jupyter[server] && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes
+          test_command: pip install pytest-jupyter[server] && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes --ignore=tests/test_doc_files_are_notebooks.py
 
   downstream_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/docs/source/developers/contents.rst
+++ b/docs/source/developers/contents.rst
@@ -63,7 +63,7 @@ Models may contain the following entries:
 |                    |``None``   |if any. (:ref:`See            |
 |                    |           |Below<modelcontent>`)         |
 +--------------------+-----------+------------------------------+
-|**md5**             |unicode or |The md5 of the contents.      |
+|**sha256**          |unicode or |The sha256 of the contents.   |
 |                    |``None``   |                              |
 |                    |           |                              |
 +--------------------+-----------+------------------------------+
@@ -80,7 +80,7 @@ model. There are three model types: **notebook**, **file**, and **directory**.
       :class:`nbformat.notebooknode.NotebookNode` representing the .ipynb file
       represented by the model.  See the `NBFormat`_ documentation for a full
       description.
-    - The ``md5`` field a hexdigest string of the md5 value of the notebook
+    - The ``sha256`` field a hexdigest string of the sha256 value of the notebook
       file.
 
 - ``file`` models
@@ -91,14 +91,14 @@ model. There are three model types: **notebook**, **file**, and **directory**.
       file models, ``content`` simply contains the file's bytes after decoding
       as UTF-8.  Non-text (``base64``) files are read as bytes, base64 encoded,
       and then decoded as UTF-8.
-    - The ``md5`` field a hexdigest string of the md5 value of the file.
+    - The ``sha256`` field a hexdigest string of the sha256 value of the file.
 
 - ``directory`` models
     - The ``format`` field is always ``"json"``.
     - The ``mimetype`` field is always ``None``.
     - The ``content`` field contains a list of :ref:`content-free<contentfree>`
       models representing the entities in the directory.
-    - The ``md5`` field is always ``None``.
+    - The ``sha256`` field is always ``None``.
 
 .. note::
 
@@ -137,7 +137,7 @@ model. There are three model types: **notebook**, **file**, and **directory**.
         "path": "foo/a.ipynb",
         "type": "notebook",
         "writable": True,
-        "md5": "7e47382b370c05a1b14706a2a8aff91a",
+        "sha256": "f5e43a0b1c2e7836ab3b4d6b1c35c19e2558688de15a6a14e137a59e4715d34b",
     }
 
     # Notebook Model without Content

--- a/docs/source/developers/contents.rst
+++ b/docs/source/developers/contents.rst
@@ -63,8 +63,12 @@ Models may contain the following entries:
 |                    |``None``   |if any. (:ref:`See            |
 |                    |           |Below<modelcontent>`)         |
 +--------------------+-----------+------------------------------+
-|**sha256**          |unicode or |The sha256 of the contents.   |
+|**hash**            |unicode or |The hash of the contents.     |
 |                    |``None``   |                              |
+|                    |           |                              |
++--------------------+-----------+------------------------------+
+|**hash_algorithm**  |unicode    |The algorithm used to compute |
+|                    |           |hash value.                   |
 |                    |           |                              |
 +--------------------+-----------+------------------------------+
 
@@ -80,8 +84,9 @@ model. There are three model types: **notebook**, **file**, and **directory**.
       :class:`nbformat.notebooknode.NotebookNode` representing the .ipynb file
       represented by the model.  See the `NBFormat`_ documentation for a full
       description.
-    - The ``sha256`` field a hexdigest string of the sha256 value of the notebook
-      file.
+    - The ``hash`` field a hexdigest string of the hash value of the file.
+      If ``ContentManager.get`` not support hash, it should always be ``None``.
+    - ``hash_algorithm`` is the algorithm used to compute the hash value.
 
 - ``file`` models
     - The ``format`` field is either ``"text"`` or ``"base64"``.
@@ -91,14 +96,16 @@ model. There are three model types: **notebook**, **file**, and **directory**.
       file models, ``content`` simply contains the file's bytes after decoding
       as UTF-8.  Non-text (``base64``) files are read as bytes, base64 encoded,
       and then decoded as UTF-8.
-    - The ``sha256`` field a hexdigest string of the sha256 value of the file.
+    - The ``hash`` field a hexdigest string of the hash value of the file.
+      If ``ContentManager.get`` not support hash, it should always be ``None``.
+    - ``hash_algorithm`` is the algorithm used to compute the hash value.
 
 - ``directory`` models
     - The ``format`` field is always ``"json"``.
     - The ``mimetype`` field is always ``None``.
     - The ``content`` field contains a list of :ref:`content-free<contentfree>`
       models representing the entities in the directory.
-    - The ``sha256`` field is always ``None``.
+    - The ``hash`` field is always ``None``.
 
 .. note::
 
@@ -137,7 +144,8 @@ model. There are three model types: **notebook**, **file**, and **directory**.
         "path": "foo/a.ipynb",
         "type": "notebook",
         "writable": True,
-        "sha256": "f5e43a0b1c2e7836ab3b4d6b1c35c19e2558688de15a6a14e137a59e4715d34b",
+        "hash": "f5e43a0b1c2e7836ab3b4d6b1c35c19e2558688de15a6a14e137a59e4715d34b",
+        "hash_algorithm": "sha256",
     }
 
     # Notebook Model without Content

--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -106,9 +106,9 @@ paths:
           in: query
           description: "Return content (0 for no content, 1 for return content)"
           type: integer
-        - name: sha256
+        - name: hash
           in: query
-          description: "Return sha256 hexdigest string of content (0 for no sha256, 1 for return sha256)"
+          description: "Return hash hexdigest string of content (0 for no hash, 1 for return hash), when ContentsManager not support hash, it will be ignored."
           type: integer
       responses:
         404:
@@ -889,7 +889,7 @@ definitions:
       kernel:
         $ref: "#/definitions/Kernel"
   Contents:
-    description: "A contents object.  The content and format keys may be null if content is not contained. The sha256 maybe null if sha256 is not contained.  If type is 'file', then the mimetype will be null."
+    description: "A contents object.  The content and format keys may be null if content is not contained. The hash maybe null if hash is not required.  If type is 'file', then the mimetype will be null."
     type: object
     required:
       - type
@@ -901,7 +901,8 @@ definitions:
       - mimetype
       - format
       - content
-      - sha256
+      - hash
+      - hash_algorithm
     properties:
       name:
         type: string
@@ -939,9 +940,12 @@ definitions:
       format:
         type: string
         description: Format of content (one of null, 'text', 'base64', 'json')
-      sha256:
+      hash:
         type: string
-        description: "The sha256 hexdigest string of content, if requested (otherwise null)."
+        description: "The hexdigest hash string of content, if requested (otherwise null)."
+      hash_algorithm:
+        type: string
+        ddescription: "The algorithm used to produce the hash."
   Checkpoints:
     description: A checkpoint object.
     type: object

--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -106,9 +106,9 @@ paths:
           in: query
           description: "Return content (0 for no content, 1 for return content)"
           type: integer
-        - name: md5
+        - name: sha256
           in: query
-          description: "Return md5 hexdigest string of content (0 for no md5, 1 for return md5)"
+          description: "Return sha256 hexdigest string of content (0 for no sha256, 1 for return sha256)"
           type: integer
       responses:
         404:
@@ -889,7 +889,7 @@ definitions:
       kernel:
         $ref: "#/definitions/Kernel"
   Contents:
-    description: "A contents object.  The content and format keys may be null if content is not contained. The md5 maybe null if md5 is not contained.  If type is 'file', then the mimetype will be null."
+    description: "A contents object.  The content and format keys may be null if content is not contained. The sha256 maybe null if sha256 is not contained.  If type is 'file', then the mimetype will be null."
     type: object
     required:
       - type
@@ -901,7 +901,7 @@ definitions:
       - mimetype
       - format
       - content
-      - md5
+      - sha256
     properties:
       name:
         type: string
@@ -939,9 +939,9 @@ definitions:
       format:
         type: string
         description: Format of content (one of null, 'text', 'base64', 'json')
-      md5:
+      sha256:
         type: string
-        description: "The md5 hexdigest string of content, if requested (otherwise null)."
+        description: "The sha256 hexdigest string of content, if requested (otherwise null)."
   Checkpoints:
     description: A checkpoint object.
     type: object

--- a/jupyter_server/services/contents/filecheckpoints.py
+++ b/jupyter_server/services/contents/filecheckpoints.py
@@ -252,7 +252,7 @@ class GenericFileCheckpoints(GenericCheckpointsMixin, FileCheckpoints):
         if not os.path.isfile(os_checkpoint_path):
             self.no_such_checkpoint(path, checkpoint_id)
 
-        content, format = self._read_file(os_checkpoint_path, format=None)
+        content, format, _ = self._read_file(os_checkpoint_path, format=None)
         return {
             "type": "file",
             "content": content,
@@ -318,7 +318,7 @@ class AsyncGenericFileCheckpoints(AsyncGenericCheckpointsMixin, AsyncFileCheckpo
         if not os.path.isfile(os_checkpoint_path):
             self.no_such_checkpoint(path, checkpoint_id)
 
-        content, format = await self._read_file(os_checkpoint_path, format=None)
+        content, format, _ = await self._read_file(os_checkpoint_path, format=None)
         return {
             "type": "file",
             "content": content,

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -357,11 +357,11 @@ class FileManagerMixin(LoggingConfigurable, Configurable):
         with self.atomic_writing(os_path, text=False) as f:
             f.write(bcontent)
 
-    def _get_md5(self, os_path):
+    def _get_sha256(self, os_path):
         c, _ = self._read_file(os_path, "byte")
-        md5 = hashlib.md5()
-        md5.update(c)
-        return md5.hexdigest()
+        sha256 = hashlib.sha256()
+        sha256.update(c)
+        return sha256.hexdigest()
 
 
 class AsyncFileManagerMixin(FileManagerMixin):
@@ -475,8 +475,8 @@ class AsyncFileManagerMixin(FileManagerMixin):
         with self.atomic_writing(os_path, text=False) as f:
             await run_sync(f.write, bcontent)
 
-    async def _get_md5(self, os_path):
+    async def _get_sha256(self, os_path):
         c, _ = await self._read_file(os_path, "byte")
-        md5 = hashlib.md5()
-        await run_sync(md5.update, c)
-        return md5.hexdigest()
+        sha256 = hashlib.sha256()
+        await run_sync(sha256.update, c)
+        return sha256.hexdigest()

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -857,6 +857,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
             model["format"] = "json"
             self.validate_notebook_model(model, validation_error)
         if require_hash:
+            # FIXME: Here we may read file twice while content=True
             model["hash"] = await self._get_hash_from_file(os_path)
 
         return model

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -48,7 +48,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
     root_dir = Unicode(config=True)
 
     max_copy_folder_size_mb = Int(500, config=True, help="The max folder size that can be copied")
-    support_md5 = Bool(True, config=False, help="Support md5 argument in `get`")
+    support_sha256 = Bool(True, config=False, help="Support sha256 argument in `get`")
 
     @default("root_dir")
     def _default_root_dir(self):
@@ -269,7 +269,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         model["mimetype"] = None
         model["size"] = size
         model["writable"] = self.is_writable(path)
-        model["md5"] = None
+        model["sha256"] = None
 
         return model
 
@@ -337,7 +337,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         return model
 
-    def _file_model(self, path, content=True, format=None, md5=False):
+    def _file_model(self, path, content=True, format=None, sha256=False):
         """Build a model for a file
 
         if content is requested, include the file contents.
@@ -366,13 +366,13 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                 content=content,
                 format=format,
             )
-        if md5:
-            md5 = self._get_md5(os_path)
-            model.update(md5=md5)
+        if sha256:
+            sha256 = self._get_sha256(os_path)
+            model.update(sha256=sha256)
 
         return model
 
-    def _notebook_model(self, path, content=True, md5=False):
+    def _notebook_model(self, path, content=True, sha256=False):
         """Build a notebook model
 
         if content is requested, the notebook content will be populated
@@ -391,12 +391,12 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             model["content"] = nb
             model["format"] = "json"
             self.validate_notebook_model(model, validation_error)
-        if md5:
-            model["md5"] = self._get_md5(os_path)
+        if sha256:
+            model["sha256"] = self._get_sha256(os_path)
 
         return model
 
-    def get(self, path, content=True, type=None, format=None, md5=None):
+    def get(self, path, content=True, type=None, format=None, sha256=None):
         """Takes a path for an entity and returns its model
 
         Parameters
@@ -411,8 +411,8 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         format : str, optional
             The requested format for file contents. 'text' or 'base64'.
             Ignored if this returns a notebook or directory model.
-        md5: bool, optional
-            Whether to include the md5 of the file contents.
+        sha256: bool, optional
+            Whether to include the sha256 of the file contents.
 
         Returns
         -------
@@ -440,11 +440,11 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                 )
             model = self._dir_model(path, content=content)
         elif type == "notebook" or (type is None and path.endswith(".ipynb")):
-            model = self._notebook_model(path, content=content, md5=md5)
+            model = self._notebook_model(path, content=content, sha256=sha256)
         else:
             if type == "directory":
                 raise web.HTTPError(400, "%s is not a directory" % path, reason="bad type")
-            model = self._file_model(path, content=content, format=format, md5=md5)
+            model = self._file_model(path, content=content, format=format, sha256=sha256)
         self.emit(data={"action": "get", "path": path})
         return model
 
@@ -726,7 +726,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, AsyncContentsManager):
     """An async file contents manager."""
 
-    support_md5 = Bool(True, config=False, help="Support md5 argument in `get`")
+    support_sha256 = Bool(True, config=False, help="Support sha256 argument in `get`")
 
     @default("checkpoints_class")
     def _checkpoints_class_default(self):
@@ -797,7 +797,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
 
         return model
 
-    async def _file_model(self, path, content=True, format=None, md5=False):
+    async def _file_model(self, path, content=True, format=None, sha256=False):
         """Build a model for a file
 
         if content is requested, include the file contents.
@@ -826,13 +826,13 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
                 content=content,
                 format=format,
             )
-        if md5:
-            md5 = await self._get_md5(os_path)
-            model.update(md5=md5)
+        if sha256:
+            sha256 = await self._get_sha256(os_path)
+            model.update(sha256=sha256)
 
         return model
 
-    async def _notebook_model(self, path, content=True, md5=False):
+    async def _notebook_model(self, path, content=True, sha256=False):
         """Build a notebook model
 
         if content is requested, the notebook content will be populated
@@ -851,12 +851,12 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
             model["content"] = nb
             model["format"] = "json"
             self.validate_notebook_model(model, validation_error)
-        if md5:
-            model["md5"] = await self._get_md5(os_path)
+        if sha256:
+            model["sha256"] = await self._get_sha256(os_path)
 
         return model
 
-    async def get(self, path, content=True, type=None, format=None, md5=False):
+    async def get(self, path, content=True, type=None, format=None, sha256=False):
         """Takes a path for an entity and returns its model
 
         Parameters
@@ -871,8 +871,8 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         format : str, optional
             The requested format for file contents. 'text' or 'base64'.
             Ignored if this returns a notebook or directory model.
-        md5: bool, optional
-            Whether to include the md5 of the file contents.
+        sha256: bool, optional
+            Whether to include the sha256 of the file contents.
 
         Returns
         -------
@@ -895,11 +895,11 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
                 )
             model = await self._dir_model(path, content=content)
         elif type == "notebook" or (type is None and path.endswith(".ipynb")):
-            model = await self._notebook_model(path, content=content, md5=md5)
+            model = await self._notebook_model(path, content=content, sha256=sha256)
         else:
             if type == "directory":
                 raise web.HTTPError(400, "%s is not a directory" % path, reason="bad type")
-            model = await self._file_model(path, content=content, format=format, md5=md5)
+            model = await self._file_model(path, content=content, format=format, sha256=sha256)
         self.emit(data={"action": "get", "path": path})
         return model
 

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -48,6 +48,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
     root_dir = Unicode(config=True)
 
     max_copy_folder_size_mb = Int(500, config=True, help="The max folder size that can be copied")
+    support_md5 = Bool(True, config=False, help="Support md5 argument in `get`")
 
     @default("root_dir")
     def _default_root_dir(self):
@@ -724,6 +725,8 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
 class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, AsyncContentsManager):
     """An async file contents manager."""
+
+    support_md5 = Bool(True, config=False, help="Support md5 argument in `get`")
 
     @default("checkpoints_class")
     def _checkpoints_class_default(self):

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -152,6 +152,9 @@ class ContentsHandler(ContentsAPIHandler):
             "format": format,
             "content": content,
         }
+
+        # See https://github.com/jupyter-server/jupyter_server/issues/1366
+        # try not breaking `ContentManager.get` API while intro `hash` argument to ContentManager
         if cm.support_hash:
             kwargs["require_hash"] = require_hash
 

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -145,16 +145,17 @@ class ContentsHandler(ContentsAPIHandler):
             await self._finish_error(
                 HTTPStatus.NOT_FOUND, f"file or directory {path!r} does not exist"
             )
+        kwargs = {
+            "path": path,
+            "type": type,
+            "format": format,
+            "content": content,
+        }
+        if cm.support_md5:
+            kwargs["md5"] = md5
+
         try:
-            model = await ensure_async(
-                self.contents_manager.get(
-                    path=path,
-                    type=type,
-                    format=format,
-                    content=content,
-                    md5=md5,
-                )
-            )
+            model = await ensure_async(self.contents_manager.get(**kwargs))
             validate_model(model, expect_content=content, expect_md5=md5)
             self._finish_model(model, location=False)
         except web.HTTPError as exc:

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -111,7 +111,7 @@ class ContentsManager(LoggingConfigurable):
         return value
 
     allow_hidden = Bool(False, config=True, help="Allow access to hidden files")
-    support_hash = Bool(False, config=False, help="Support hash argument in `get`")
+    support_hash = Bool(False, config=False, help="Support require_hash argument in `get`")
 
     notary = Instance(sign.NotebookNotary)
 

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -111,6 +111,7 @@ class ContentsManager(LoggingConfigurable):
         return value
 
     allow_hidden = Bool(False, config=True, help="Allow access to hidden files")
+    support_md5 = Bool(False, config=False, help="Support md5 argument in `get`")
 
     notary = Instance(sign.NotebookNotary)
 
@@ -447,8 +448,14 @@ class ContentsManager(LoggingConfigurable):
         """
         return self.file_exists(path) or self.dir_exists(path)
 
-    def get(self, path, content=True, type=None, format=None, md5=False):
-        """Get a file or directory model."""
+    def get(self, path, content=True, type=None, format=None):
+        """
+        Get a file or directory model.
+
+        If a ContentManager supports calculating the md5 value of a file,
+        `ContentManager.support_md5` should be True and this function will accept an `md5` parameter,
+        will return a dict with an `md5` key.
+        """
         raise NotImplementedError
 
     def save(self, model, path):
@@ -850,7 +857,13 @@ class AsyncContentsManager(ContentsManager):
         )
 
     async def get(self, path, content=True, type=None, format=None):
-        """Get a file or directory model."""
+        """
+        Get a file or directory model.
+
+        If a ContentManager supports calculating the md5 value of a file,
+        ContentManager.support_md5 should be True and this function will accept an md5 parameter,
+        will return a dict with an 'md5' key.
+        """
         raise NotImplementedError
 
     async def save(self, model, path):

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -111,7 +111,7 @@ class ContentsManager(LoggingConfigurable):
         return value
 
     allow_hidden = Bool(False, config=True, help="Allow access to hidden files")
-    support_sha256 = Bool(False, config=False, help="Support sha256 argument in `get`")
+    support_hash = Bool(False, config=False, help="Support hash argument in `get`")
 
     notary = Instance(sign.NotebookNotary)
 
@@ -452,9 +452,10 @@ class ContentsManager(LoggingConfigurable):
         """
         Get a file or directory model.
 
-        If a ContentManager supports calculating the sha256 value of a file,
-        `ContentManager.support_sha256` should be True and this function will accept an `sha256` parameter,
-        will return a dict with an `sha256` key.
+        Support for hash:
+            If a ContentManager supports calculating the hash value of a file,
+            `ContentManager.support_hash` should be True and this function will accept an `require_hash` parameter,
+            will return a dict with `hash` and `hash_algorithm` key.
         """
         raise NotImplementedError
 
@@ -860,9 +861,10 @@ class AsyncContentsManager(ContentsManager):
         """
         Get a file or directory model.
 
-        If a ContentManager supports calculating the sha256 value of a file,
-        ContentManager.support_sha256 should be True and this function will accept an sha256 parameter,
-        will return a dict with an 'sha256' key.
+        Support for hash:
+            If a ContentManager supports calculating the hash value of a file,
+            `ContentManager.support_hash` should be True and this function will accept an `require_hash` parameter,
+            will return a dict with `hash` and `hash_algorithm` key.
         """
         raise NotImplementedError
 

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -111,7 +111,7 @@ class ContentsManager(LoggingConfigurable):
         return value
 
     allow_hidden = Bool(False, config=True, help="Allow access to hidden files")
-    support_md5 = Bool(False, config=False, help="Support md5 argument in `get`")
+    support_sha256 = Bool(False, config=False, help="Support sha256 argument in `get`")
 
     notary = Instance(sign.NotebookNotary)
 
@@ -452,9 +452,9 @@ class ContentsManager(LoggingConfigurable):
         """
         Get a file or directory model.
 
-        If a ContentManager supports calculating the md5 value of a file,
-        `ContentManager.support_md5` should be True and this function will accept an `md5` parameter,
-        will return a dict with an `md5` key.
+        If a ContentManager supports calculating the sha256 value of a file,
+        `ContentManager.support_sha256` should be True and this function will accept an `sha256` parameter,
+        will return a dict with an `sha256` key.
         """
         raise NotImplementedError
 
@@ -860,9 +860,9 @@ class AsyncContentsManager(ContentsManager):
         """
         Get a file or directory model.
 
-        If a ContentManager supports calculating the md5 value of a file,
-        ContentManager.support_md5 should be True and this function will accept an md5 parameter,
-        will return a dict with an 'md5' key.
+        If a ContentManager supports calculating the sha256 value of a file,
+        ContentManager.support_sha256 should be True and this function will accept an sha256 parameter,
+        will return a dict with an 'sha256' key.
         """
         raise NotImplementedError
 

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -103,15 +103,15 @@ async def test_get_nb_contents(jp_fetch, contents, path, name):
 
 
 @pytest.mark.parametrize("path,name", dirs)
-async def test_get_nb_md5(jp_fetch, contents, path, name):
+async def test_get_nb_sha256(jp_fetch, contents, path, name):
     nbname = name + ".ipynb"
     nbpath = (path + "/" + nbname).lstrip("/")
-    r = await jp_fetch("api", "contents", nbpath, method="GET", params=dict(md5="1"))
+    r = await jp_fetch("api", "contents", nbpath, method="GET", params=dict(sha256="1"))
     model = json.loads(r.body.decode())
     assert model["name"] == nbname
     assert model["path"] == nbpath
     assert model["type"] == "notebook"
-    assert "md5" in model
+    assert "sha256" in model
     assert "metadata" in model["content"]
     assert isinstance(model["content"]["metadata"], dict)
 
@@ -201,14 +201,14 @@ async def test_get_text_file_contents(jp_fetch, contents, path, name):
 
 
 @pytest.mark.parametrize("path,name", dirs)
-async def test_get_text_file_md5(jp_fetch, contents, path, name):
+async def test_get_text_file_sha256(jp_fetch, contents, path, name):
     txtname = name + ".txt"
     txtpath = (path + "/" + txtname).lstrip("/")
-    r = await jp_fetch("api", "contents", txtpath, method="GET", params=dict(md5="1"))
+    r = await jp_fetch("api", "contents", txtpath, method="GET", params=dict(sha256="1"))
     model = json.loads(r.body.decode())
     assert model["name"] == txtname
     assert model["path"] == txtpath
-    assert "md5" in model
+    assert "sha256" in model
     assert model["format"] == "text"
     assert model["type"] == "file"
 

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -97,21 +97,26 @@ async def test_get_nb_contents(jp_fetch, contents, path, name):
     assert model["path"] == nbpath
     assert model["type"] == "notebook"
     assert "content" in model
+    assert "hash" in model
+    assert model["hash"] == None
+    assert "hash_algorithm" in model
     assert model["format"] == "json"
     assert "metadata" in model["content"]
     assert isinstance(model["content"]["metadata"], dict)
 
 
 @pytest.mark.parametrize("path,name", dirs)
-async def test_get_nb_sha256(jp_fetch, contents, path, name):
+async def test_get_nb_hash(jp_fetch, contents, path, name):
     nbname = name + ".ipynb"
     nbpath = (path + "/" + nbname).lstrip("/")
-    r = await jp_fetch("api", "contents", nbpath, method="GET", params=dict(sha256="1"))
+    r = await jp_fetch("api", "contents", nbpath, method="GET", params=dict(hash="1"))
     model = json.loads(r.body.decode())
     assert model["name"] == nbname
     assert model["path"] == nbpath
     assert model["type"] == "notebook"
-    assert "sha256" in model
+    assert "hash" in model
+    assert model["hash"]
+    assert "hash_algorithm" in model
     assert "metadata" in model["content"]
     assert isinstance(model["content"]["metadata"], dict)
 
@@ -125,6 +130,9 @@ async def test_get_nb_no_contents(jp_fetch, contents, path, name):
     assert model["name"] == nbname
     assert model["path"] == nbpath
     assert model["type"] == "notebook"
+    assert "hash" in model
+    assert model["hash"] == None
+    assert "hash_algorithm" in model
     assert "content" in model
     assert model["content"] is None
 
@@ -175,6 +183,9 @@ async def test_get_text_file_contents(jp_fetch, contents, path, name):
     model = json.loads(r.body.decode())
     assert model["name"] == txtname
     assert model["path"] == txtpath
+    assert "hash" in model
+    assert model["hash"] == None
+    assert "hash_algorithm" in model
     assert "content" in model
     assert model["format"] == "text"
     assert model["type"] == "file"
@@ -201,14 +212,16 @@ async def test_get_text_file_contents(jp_fetch, contents, path, name):
 
 
 @pytest.mark.parametrize("path,name", dirs)
-async def test_get_text_file_sha256(jp_fetch, contents, path, name):
+async def test_get_text_file_hash(jp_fetch, contents, path, name):
     txtname = name + ".txt"
     txtpath = (path + "/" + txtname).lstrip("/")
-    r = await jp_fetch("api", "contents", txtpath, method="GET", params=dict(sha256="1"))
+    r = await jp_fetch("api", "contents", txtpath, method="GET", params=dict(hash="1"))
     model = json.loads(r.body.decode())
     assert model["name"] == txtname
     assert model["path"] == txtpath
-    assert "sha256" in model
+    assert "hash" in model
+    assert model["hash"]
+    assert "hash_algorithm" in model
     assert model["format"] == "text"
     assert model["type"] == "file"
 
@@ -253,6 +266,9 @@ async def test_get_binary_file_contents(jp_fetch, contents, path, name):
     assert model["name"] == blobname
     assert model["path"] == blobpath
     assert "content" in model
+    assert "hash" in model
+    assert model["hash"] == None
+    assert "hash_algorithm" in model
     assert model["format"] == "base64"
     assert model["type"] == "file"
     data_out = decodebytes(model["content"].encode("ascii"))

--- a/tests/services/contents/test_fileio.py
+++ b/tests/services/contents/test_fileio.py
@@ -142,8 +142,11 @@ def test_file_manager_mixin(tmpdir):
     mixin.log = logging.getLogger()
     bad_content = tmpdir / "bad_content.ipynb"
     bad_content.write_text("{}", "utf8")
-    # Same as `echo -n {} | md5sum`
-    assert mixin._get_md5(bad_content) == "99914b932bd37a50b983c5e7c90ae93b"
+    # Same as `echo -n {} | sha256sum`
+    assert (
+        mixin._get_sha256(bad_content)
+        == "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    )
     with pytest.raises(HTTPError):
         mixin._read_notebook(bad_content)
     other = path_to_intermediate(bad_content)
@@ -166,8 +169,11 @@ async def test_async_file_manager_mixin(tmpdir):
     mixin.log = logging.getLogger()
     bad_content = tmpdir / "bad_content.ipynb"
     bad_content.write_text("{}", "utf8")
-    # Same as `echo -n {} | md5sum`
-    assert await mixin._get_md5(bad_content) == "99914b932bd37a50b983c5e7c90ae93b"
+    # Same as `echo -n {} | sha256sum`
+    assert (
+        await mixin._get_sha256(bad_content)
+        == "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    )
     with pytest.raises(HTTPError):
         await mixin._read_notebook(bad_content)
     other = path_to_intermediate(bad_content)

--- a/tests/services/contents/test_fileio.py
+++ b/tests/services/contents/test_fileio.py
@@ -144,7 +144,7 @@ def test_file_manager_mixin(tmpdir):
     bad_content.write_text("{}", "utf8")
     # Same as `echo -n {} | sha256sum`
     assert (
-        mixin._get_sha256(bad_content)
+        mixin._get_hash_from_file(bad_content)
         == "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
     )
     with pytest.raises(HTTPError):
@@ -171,7 +171,7 @@ async def test_async_file_manager_mixin(tmpdir):
     bad_content.write_text("{}", "utf8")
     # Same as `echo -n {} | sha256sum`
     assert (
-        await mixin._get_sha256(bad_content)
+        await mixin._get_hash_from_file(bad_content)
         == "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
     )
     with pytest.raises(HTTPError):

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -571,8 +571,8 @@ async def test_get(jp_contents_manager):
     nb_as_bin_file = await ensure_async(cm.get(path, content=True, type="file", format="base64"))
     assert nb_as_bin_file["format"] == "base64"
 
-    nb_with_sha256 = await ensure_async(cm.get(path, sha256=True))
-    assert nb_with_sha256["sha256"]
+    nb_with_hash = await ensure_async(cm.get(path, require_hash=True))
+    assert nb_with_hash["hash"]
 
     # Test in sub-directory
     sub_dir = "/foo/"
@@ -588,7 +588,7 @@ async def test_get(jp_contents_manager):
 
     # Test with a regular file.
     file_model_path = (await ensure_async(cm.new_untitled(path=sub_dir, ext=".txt")))["path"]
-    file_model = await ensure_async(cm.get(file_model_path, sha256=True))
+    file_model = await ensure_async(cm.get(file_model_path, require_hash=True))
     expected_model = {
         "content": "",
         "format": "text",
@@ -603,7 +603,7 @@ async def test_get(jp_contents_manager):
         assert file_model[key] == value
     assert "created" in file_model
     assert "last_modified" in file_model
-    assert "sha256" in file_model
+    assert "hash" in file_model
 
     # Create a sub-sub directory to test getting directory contents with a
     # subdir.

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -571,8 +571,8 @@ async def test_get(jp_contents_manager):
     nb_as_bin_file = await ensure_async(cm.get(path, content=True, type="file", format="base64"))
     assert nb_as_bin_file["format"] == "base64"
 
-    nb_with_md5 = await ensure_async(cm.get(path, md5=True))
-    assert nb_with_md5["md5"]
+    nb_with_sha256 = await ensure_async(cm.get(path, sha256=True))
+    assert nb_with_sha256["sha256"]
 
     # Test in sub-directory
     sub_dir = "/foo/"
@@ -588,7 +588,7 @@ async def test_get(jp_contents_manager):
 
     # Test with a regular file.
     file_model_path = (await ensure_async(cm.new_untitled(path=sub_dir, ext=".txt")))["path"]
-    file_model = await ensure_async(cm.get(file_model_path, md5=True))
+    file_model = await ensure_async(cm.get(file_model_path, sha256=True))
     expected_model = {
         "content": "",
         "format": "text",
@@ -603,7 +603,7 @@ async def test_get(jp_contents_manager):
         assert file_model[key] == value
     assert "created" in file_model
     assert "last_modified" in file_model
-    assert "md5" in file_model
+    assert "sha256" in file_model
 
     # Create a sub-sub directory to test getting directory contents with a
     # subdir.


### PR DESCRIPTION
This modifies https://github.com/jupyter-server/jupyter_server/pull/1367 in order to:

- allow only a valid hash algorithm from hashlib available algorithms
- don't require a new attribute on `ContentsManager` as contents manager are expected to update to the latest API supporting hash
- Make `Mixin` classes backward compatible as they may be reused downstream
- Don't change the purpose of `_read_file` (it only read files)
- Limit the number of new methods (only adds `_get_hash`)
- Don't set `hash_algorithm` except if `hash` is set
- Don't set the content if we only want the hash (it will avoid encoding the bytes for example)
- Don't read twice the content for notebooks

@Wh1isper feel free to cherry-pick my commits to your branch. I would strongly suggest removing the downstream test against `jupytext` because we have already very limited maintenance capability.